### PR TITLE
Add drawing features in drawutils

### DIFF
--- a/demos/basic.c
+++ b/demos/basic.c
@@ -7,26 +7,29 @@ int init_stripes()
 {
     int width = get_width();
     int height = get_height();
+    shade(MID);
+    colour(Unset);
     enum Shade line_shade = MID;
-    enum Colour colour = Unset;
+    enum Colour col = Unset;
 
     for (int i = 0; i < height; i++) {
-        draw_line(0, i, width, i, line_shade, colour);
+        line(0, i, width, i);
         line_shade = line_shade == MID ? LGT : MID;
+        shade(line_shade);
     }
 
     set_pen(get_width() - 3, get_height() - 1);
-    set_pixel_at_pen(DRK, colour);
-    set_pixel_at_pen(LGT, colour);
-    set_pixel_at_pen(DRK, colour);
-    set_pixel_at_pen(LGT, colour);
-    set_pixel_at_pen(DRK, colour);
-    set_pixel_at_pen(LGT, colour);
+    set_pixel_at_pen(DRK, col);
+    set_pixel_at_pen(LGT, col);
+    set_pixel_at_pen(DRK, col);
+    set_pixel_at_pen(LGT, col);
+    set_pixel_at_pen(DRK, col);
+    set_pixel_at_pen(LGT, col);
 
     set_pen(0,0);
-    set_pixel_at_pen(CLR, colour);
+    set_pixel_at_pen(CLR, col);
     set_pen(get_width() - 1, get_height() - 1);
-    set_pixel_at_pen(CLR, colour);
+    set_pixel_at_pen(CLR, col);
 
     return 0;
 }

--- a/src/drawutils.c
+++ b/src/drawutils.c
@@ -19,6 +19,16 @@ struct setting Settings = {
     .col = White,
 };
 
+void shade(enum Shade new)
+{
+    Settings.shd = new;
+}
+
+void colour(enum Colour new)
+{
+    Settings.col = new;
+}
+
 void line(int x1, int y1, int x2, int y2)
 {
     if (!line_clip(&x1, &y1, &x2, &y2, 0, get_width(), 0, get_height()))

--- a/src/drawutils.c
+++ b/src/drawutils.c
@@ -52,12 +52,12 @@ void mode(enum Rectmode mode)
 void rotate(float angle)
 {
     if (angle >= 360.0f)	/* Wrap angle */
-	angle = fmod(angle, 360.0f);
+        angle = fmod(angle, 360.0f);
 
     state.rotate_angle += angle;
 
     if (state.rotate_angle >= 360.0f) /* Wrap theta */
-	state.rotate_angle -= 360.0f;
+        state.rotate_angle -= 360.0f;
 }
 
 void scale(float factor)
@@ -97,20 +97,20 @@ void line(int x1, int y1, int x2, int y2)
 
     while (1) {
         set_pixel(x1, y1, state.shd, state.col);
-	if (x1 == x2 && y1 == y2)
-	    break;
+        if (x1 == x2 && y1 == y2)
+            break;
 
-	error = 2 * dxy;
+        error = 2 * dxy;
 
-	if (error >= dy) {	/* error_xy + error_x > 0 */
-	    dxy += dy;
-	    x1 += step_x;
-	}
+        if (error >= dy) {	/* error_xy + error_x > 0 */
+            dxy += dy;
+            x1 += step_x;
+        }
 
-	if (error <= dx) {	/* error_xy + error_y < 0 */
-	    dxy += dx;
-	    y1 += step_y;
-	}
+        if (error <= dx) {	/* error_xy + error_y < 0 */
+            dxy += dx;
+            y1 += step_y;
+        }
     }
 }
 

--- a/src/drawutils.c
+++ b/src/drawutils.c
@@ -107,9 +107,9 @@ void line(int x1, int y1, int x2, int y2)
 void rect(int x, int y, int w, int h)
 {
     line(x, y, x + w, y);
-    line(x, y + h, x + w, y + h);
-    line(x, y, x, y + h);
-    line(x + w, y, x + w, y + h);
+    line(x, y - h, x + w, y - h);
+    line(x, y, x, y - h);
+    line(x + w, y, x + w, y - h);
 }
 
 void ellipse(int x, int y, int w, int h)

--- a/src/drawutils.c
+++ b/src/drawutils.c
@@ -19,7 +19,7 @@ struct setting Settings = {
     .col = White,
 };
 
-void draw_line(int x1, int y1, int x2, int y2)
+void line(int x1, int y1, int x2, int y2)
 {
     if (!line_clip(&x1, &y1, &x2, &y2, 0, get_width(), 0, get_height()))
         return;
@@ -42,15 +42,15 @@ void draw_line(int x1, int y1, int x2, int y2)
     }
 }
 
-void draw_rect(int x, int y, int w, int h)
+void rect(int x, int y, int w, int h)
 {
-    draw_line(x, y, x + w, y);
-    draw_line(x, y + h - 1, x + w, y + h - 1);
-    draw_line(x, y + 1, x, y + h - 1);
-    draw_line(x + w - 1, y + 1, x + w - 1, y + h - 1);
+    line(x, y, x + w, y);
+    line(x, y + h - 1, x + w, y + h - 1);
+    line(x, y + 1, x, y + h - 1);
+    line(x + w - 1, y + 1, x + w - 1, y + h - 1);
 }
 
-void draw_elipse(int x, int y, int w, int h)
+void ellipse(int x, int y, int w, int h)
 {
     // Major (a) and Minor (b) axes
     float a = w >= h ? w / 2 : h / 2;

--- a/src/drawutils.c
+++ b/src/drawutils.c
@@ -14,7 +14,12 @@ int line_clip(int *x0_out, int *y0_out, int *x1_out, int *y1_out,
  * - Better response to error-case(s)
  */
 
-void draw_line(int x1, int y1, int x2, int y2, enum Shade px_type, enum Colour px_col)
+struct setting Settings = {
+    .shd = BLK,		/* C99 */
+    .col = White,
+};
+
+void draw_line(int x1, int y1, int x2, int y2)
 {
     if (!line_clip(&x1, &y1, &x2, &y2, 0, get_width(), 0, get_height()))
         return;
@@ -31,23 +36,21 @@ void draw_line(int x1, int y1, int x2, int y2, enum Shade px_type, enum Colour p
     float cur_y = y1;
 
     for (int i = 0; i < steps; i++) {
-        set_pixel((int)cur_x, (int)cur_y, px_type, px_col);
+        set_pixel((int)cur_x, (int)cur_y, Settings.shd, Settings.col);
         cur_x += x_step;
         cur_y += y_step;
     }
 }
 
-void draw_rect(int x, int y, int w, int h, enum Shade shd, enum Shade fill_shd,
-               enum Colour col, enum Colour fill_col)
+void draw_rect(int x, int y, int w, int h)
 {
-    draw_line(x, y, x + w, y, shd, col);
-    draw_line(x, y + h - 1, x + w, y + h - 1, shd, col);
-    draw_line(x, y + 1, x, y + h - 1, shd, col);
-    draw_line(x + w - 1, y + 1, x + w - 1, y + h - 1, shd, col);
+    draw_line(x, y, x + w, y);
+    draw_line(x, y + h - 1, x + w, y + h - 1);
+    draw_line(x, y + 1, x, y + h - 1);
+    draw_line(x + w - 1, y + 1, x + w - 1, y + h - 1);
 }
 
-void draw_elipse(int x, int y, int w, int h, enum Shade shd, enum Shade fill_shd,
-                 enum Colour col, enum Colour fill_col)
+void draw_elipse(int x, int y, int w, int h)
 {
     // Major (a) and Minor (b) axes
     float a = w >= h ? w / 2 : h / 2;
@@ -59,7 +62,7 @@ void draw_elipse(int x, int y, int w, int h, enum Shade shd, enum Shade fill_shd
     for (float i = 0; i < 360; i += 0.5) {
         int px_x = a * cos(i) + x_offset;
         int px_y = b * sin(i) + y_offset;
-        set_pixel(px_x, px_y, shd, col);
+        set_pixel(px_x, px_y, Settings.shd, Settings.col);
     }
 }
 

--- a/src/drawutils.c
+++ b/src/drawutils.c
@@ -19,6 +19,11 @@ struct setting Settings = {
     .col = White,
 };
 
+struct point Origin = {
+    .x = 0,
+    .y = 0,
+};
+
 void shade(enum Shade new)
 {
     Settings.shd = new;
@@ -27,6 +32,12 @@ void shade(enum Shade new)
 void colour(enum Colour new)
 {
     Settings.col = new;
+}
+
+void translate(int x, int y)
+{
+    Origin.x = x;
+    Origin.y = y;
 }
 
 void line(int x1, int y1, int x2, int y2)

--- a/src/drawutils.c
+++ b/src/drawutils.c
@@ -70,37 +70,46 @@ void line(int x1, int y1, int x2, int y2)
     rotate_point(&x1, &y1);
     rotate_point(&x2, &y2);
 
-    /* if (!line_clip(&x1, &y1, &x2, &y2, 0, get_width(), 0, get_height())) */
-    /*     return; */
-
     x1 = state.origin.x + state.scale_factor * x1;
     x2 = state.origin.x + state.scale_factor * x2;
     y1 = state.origin.y + state.scale_factor * y1;
     y2 = state.origin.y + state.scale_factor * y2;
-    int dx = x2 - x1;
-    int dy = y2 - y1;
 
-    int steps = abs(dx) > abs(dy) ? abs(dx) : abs(dy);
+    /* if (!line_clip(&x1, &y1, &x2, &y2, 0, get_width(), 0, get_height())) */
+    /*     return; */
 
-    float x_step = (float)dx / steps;
-    float y_step = (float)dy / steps;
+    int dx = abs(x2 - x1);
+    int dy = -abs(y2 - y1);
+    int step_x = x1 < x2 ? 1 : -1;
+    int step_y = y1 < y2 ? 1 : -1;
+    int dxy = dx + dy;
+    int error;
 
-    float cur_x = x1;
-    float cur_y = y1;
+    while (1) {
+        set_pixel(x1, y1, state.shd, state.col);
+	if (x1 == x2 && y1 == y2)
+	    break;
 
-    for (int i = 0; i < steps; i++) {
-        set_pixel((int)cur_x, (int)cur_y, state.shd, state.col);
-        cur_x += x_step;
-        cur_y += y_step;
+	error = 2 * dxy;
+
+	if (error >= dy) {	/* error_xy + error_x > 0 */
+	    dxy += dy;
+	    x1 += step_x;
+	}
+
+	if (error <= dx) {	/* error_xy + error_y < 0 */
+	    dxy += dx;
+	    y1 += step_y;
+	}
     }
 }
 
 void rect(int x, int y, int w, int h)
 {
     line(x, y, x + w, y);
-    line(x, y + h - 1, x + w, y + h - 1);
-    line(x, y + 1, x, y + h - 1);
-    line(x + w - 1, y + 1, x + w - 1, y + h - 1);
+    line(x, y + h, x + w, y + h);
+    line(x, y, x, y + h);
+    line(x + w, y, x + w, y + h);
 }
 
 void ellipse(int x, int y, int w, int h)

--- a/src/drawutils.c
+++ b/src/drawutils.c
@@ -61,28 +61,27 @@ void scale(float factor)
     scaling *= factor;
 }
 
-static struct point *rotated_point(int x, int y)
+static void rotate_point(int *x, int *y)
 {
-    struct point *out = malloc(sizeof(struct point));
     float rads = theta * PI / 180.0f;
+    int tmp = *x;
 
-    out->x = x * cos(rads) - y * sin(rads);
-    out->y = x * sin(rads) + y * cos(rads);
-
-    return out;
+    *x = *x * cos(rads) - *y * sin(rads);
+    *y = tmp * sin(rads) + *y * cos(rads);
 }
 
 void line(int x1, int y1, int x2, int y2)
 {
-    struct point *point1 = rotated_point(x1, y1);
-    struct point *point2 = rotated_point(x2, y2);
+    rotate_point(&x1, &y1);
+    rotate_point(&x2, &y2);
+
     /* if (!line_clip(&x1, &y1, &x2, &y2, 0, get_width(), 0, get_height())) */
     /*     return; */
 
-    x1 = Origin.x + scaling * point1->x;
-    x2 = Origin.x + scaling * point2->x;
-    y1 = Origin.y + scaling * point1->y;
-    y2 = Origin.y + scaling * point2->y;
+    x1 = Origin.x + scaling * x1;
+    x2 = Origin.x + scaling * x2;
+    y1 = Origin.y + scaling * y1;
+    y2 = Origin.y + scaling * y2;
     int dx = x2 - x1;
     int dy = y2 - y1;
 
@@ -99,9 +98,6 @@ void line(int x1, int y1, int x2, int y2)
         cur_x += x_step;
         cur_y += y_step;
     }
-
-    free(point1);
-    free(point2);
 }
 
 void rect(int x, int y, int w, int h)
@@ -114,9 +110,9 @@ void rect(int x, int y, int w, int h)
 
 void ellipse(int x, int y, int w, int h)
 {
-    struct point *point = rotated_point(x, y);
-    x = Origin.x + scaling * point->x;
-    y = Origin.y + scaling * point->y;
+    rotate_point(&x, &y);
+    x = Origin.x + scaling * x;
+    y = Origin.y + scaling * y;
 
     // Major (a) and Minor (b) axes
     float a = w >= h ? w / 2 : h / 2;
@@ -130,8 +126,6 @@ void ellipse(int x, int y, int w, int h)
         int px_y = b * sin(i) + y_offset;
         set_pixel(px_x, px_y, Settings.shd, Settings.col);
     }
-
-    free(point);
 }
 
 

--- a/src/drawutils.c
+++ b/src/drawutils.c
@@ -23,6 +23,7 @@ static struct Settings state = {
     .origin = {0, 0},		/* C99 */
     .rotate_angle = 0.0f,
     .scale_factor = 1.0f,
+    .mode = XY,
     .shd = BLK,
     .col = White,
 };
@@ -41,6 +42,11 @@ void translate(int x, int y)
 {
     state.origin.x = x;
     state.origin.y = y;
+}
+
+void mode(enum Rectmode mode)
+{
+    state.mode = mode;
 }
 
 void rotate(float angle)
@@ -145,9 +151,11 @@ void ellipse(int x, int y, int w, int h)
     float yf2 = yf * yf;
 
     /* Centre */
-    x += IS_EVEN(w) ? w / 2 : w / 2 + 1; /* TODO: why not round()? */
-    y -= IS_EVEN(h) ? h / 2 : h / 2 + 1;
-    rotate_point(&x, &y);
+    if (state.mode == XY) {
+        x += IS_EVEN(w) ? w / 2 : w / 2 + 1; /* TODO: why not round()? */
+        y -= IS_EVEN(h) ? h / 2 : h / 2 + 1;
+        rotate_point(&x, &y);
+    }
     int cx = state.origin.x + x;
     int cy = state.origin.y + y;
 

--- a/src/drawutils.c
+++ b/src/drawutils.c
@@ -25,7 +25,8 @@ struct point Origin = {
     .y = 0,
 };
 
-float theta = 0.0f;
+float theta = 0.0f;		/* Rotation angle, additive */
+float scaling = 1.0f;		/* Scaling factor, multiplicative */
 
 void shade(enum Shade new)
 {
@@ -54,6 +55,12 @@ void rotate(float angle)
 	theta -= 360.0f;
 }
 
+void scale(float factor)
+{
+    factor = fabs(factor);	/* Don't allow negative scaling*/
+    scaling *= factor;
+}
+
 static struct point *rotated_point(int x, int y)
 {
     struct point *out = malloc(sizeof(struct point));
@@ -72,10 +79,10 @@ void line(int x1, int y1, int x2, int y2)
     /* if (!line_clip(&x1, &y1, &x2, &y2, 0, get_width(), 0, get_height())) */
     /*     return; */
 
-    x1 = Origin.x + point1->x;
-    x2 = Origin.x + point2->x;
-    y1 = Origin.y + point1->y;
-    y2 = Origin.y + point2->y;
+    x1 = Origin.x + scaling * point1->x;
+    x2 = Origin.x + scaling * point2->x;
+    y1 = Origin.y + scaling * point1->y;
+    y2 = Origin.y + scaling * point2->y;
     int dx = x2 - x1;
     int dy = y2 - y1;
 
@@ -108,8 +115,8 @@ void rect(int x, int y, int w, int h)
 void ellipse(int x, int y, int w, int h)
 {
     struct point *point = rotated_point(x, y);
-    x = Origin.x + point->x;
-    y = Origin.y + point->y;
+    x = Origin.x + scaling * point->x;
+    y = Origin.y + scaling * point->y;
 
     // Major (a) and Minor (b) axes
     float a = w >= h ? w / 2 : h / 2;

--- a/src/drawutils.c
+++ b/src/drawutils.c
@@ -61,8 +61,8 @@ static void rotate_point(int *x, int *y)
     float rads = state.rotate_angle * PI / 180.0f;
     int tmp = *x;
 
-    *x = *x * cos(rads) - *y * sin(rads);
-    *y = tmp * sin(rads) + *y * cos(rads);
+    *x = round(*x * cos(rads) - *y * sin(rads));
+    *y = round(tmp * sin(rads) + *y * cos(rads));
 }
 
 void line(int x1, int y1, int x2, int y2)

--- a/src/drawutils.h
+++ b/src/drawutils.h
@@ -4,23 +4,24 @@
 
 #include "screen.h"
 
-struct setting {
+struct Point {
+    int x;
+    int y;
+};
+
+struct Settings {
+    struct Point origin;
+    float rotate_angle;
+    float scale_factor;
     enum Shade shd;
     enum Colour col;
 };
 
 void shade(enum Shade);
 void colour(enum Colour);
-
-struct point {
-    int x;
-    int y;
-};
-
 void translate(int, int);
 void rotate(float);
 void scale(float);
-
 void line(int, int, int, int);
 void rect(int, int, int, int);
 void ellipse(int, int, int, int);

--- a/src/drawutils.h
+++ b/src/drawutils.h
@@ -19,6 +19,7 @@ struct point {
 
 void translate(int, int);
 void rotate(float);
+void scale(float);
 
 void line(int, int, int, int);
 void rect(int, int, int, int);

--- a/src/drawutils.h
+++ b/src/drawutils.h
@@ -9,7 +9,9 @@ struct setting {
     enum Colour col;
 };
 
-// TODO: Remove superfluous `draw_` prefix
+void shade(enum Shade);
+void colour(enum Colour);
+
 void line(int, int, int, int);
 void rect(int, int, int, int);
 void ellipse(int, int, int, int);

--- a/src/drawutils.h
+++ b/src/drawutils.h
@@ -10,8 +10,8 @@ struct setting {
 };
 
 // TODO: Remove superfluous `draw_` prefix
-void draw_line(int, int, int, int);
-void draw_rect(int, int, int, int);
-void draw_elipse(int, int, int, int);
+void line(int, int, int, int);
+void rect(int, int, int, int);
+void ellipse(int, int, int, int);
 
 #endif /* DRAWUTILS_H */

--- a/src/drawutils.h
+++ b/src/drawutils.h
@@ -4,6 +4,8 @@
 
 #include "screen.h"
 
+enum Rectmode {CENTRE, XY};
+
 struct Point {
     int x;
     int y;
@@ -13,12 +15,14 @@ struct Settings {
     struct Point origin;
     float rotate_angle;
     float scale_factor;
+    enum Rectmode mode;
     enum Shade shd;
     enum Colour col;
 };
 
 void shade(enum Shade);
 void colour(enum Colour);
+void mode(enum Rectmode);
 void translate(int, int);
 void rotate(float);
 void scale(float);

--- a/src/drawutils.h
+++ b/src/drawutils.h
@@ -4,9 +4,14 @@
 
 #include "screen.h"
 
+struct setting {
+    enum Shade shd;
+    enum Colour col;
+};
+
 // TODO: Remove superfluous `draw_` prefix
-void draw_line(int, int, int, int, enum Shade, enum Colour);
-void draw_rect(int, int, int, int, enum Shade, enum Shade, enum Colour, enum Colour);
-void draw_elipse(int, int, int, int, enum Shade, enum Shade, enum Colour, enum Colour);
+void draw_line(int, int, int, int);
+void draw_rect(int, int, int, int);
+void draw_elipse(int, int, int, int);
 
 #endif /* DRAWUTILS_H */

--- a/src/drawutils.h
+++ b/src/drawutils.h
@@ -18,6 +18,7 @@ struct point {
 };
 
 void translate(int, int);
+void rotate(float);
 
 void line(int, int, int, int);
 void rect(int, int, int, int);

--- a/src/drawutils.h
+++ b/src/drawutils.h
@@ -12,6 +12,13 @@ struct setting {
 void shade(enum Shade);
 void colour(enum Colour);
 
+struct point {
+    int x;
+    int y;
+};
+
+void translate(int, int);
+
 void line(int, int, int, int);
 void rect(int, int, int, int);
 void ellipse(int, int, int, int);

--- a/tests/colours.c
+++ b/tests/colours.c
@@ -4,13 +4,14 @@
 
 int init_colours()
 {
-    enum Shade line_shade = BLK;
+    shade(BLK);
     enum Colour c[16] = {Black, Red, Green, Yellow, Blue, Magenta, Cyan, White,
                          BBlack, BRed, BGreen, BYellow, BBlue, BMagenta, BCyan, BWhite};
     int width = get_width();
 
     for (int i = 0; i < 16; i++) {
-        draw_line(0, i, width, i, line_shade, c[i]);
+        colour(c[i]);
+        line(0, i, width, i);
     }
 
     return 0;

--- a/tests/primitives.c
+++ b/tests/primitives.c
@@ -32,28 +32,28 @@ int main(int argc, char **argv)
                      .x2 = get_width() / 2, .y2 = 0};
     //draw_line(l.x1, l.y1, l.x2, l.y2, DRK, Blue);
 
-    draw_line(0, 0, 0, get_height(), BLK, Green);
-    draw_line(1, 0, 1, get_height() - 1, BLK, Green);
-    draw_line(get_width() - 1, 2, get_width() - 1, get_height(), BLK, Green);
+    draw_line(0, 0, 0, get_height());
+    draw_line(1, 0, 1, get_height() - 1);
+    draw_line(get_width() - 1, 2, get_width() - 1, get_height());
 
-    draw_line(2, 0, get_width(), 0, BLK, Blue);
-    draw_line(2, 1, get_width() - 1, 1, BLK, Blue);
-    draw_line(2, get_height() - 1, get_width() - 1, get_height() - 1, BLK, Blue);
+    draw_line(2, 0, get_width(), 0);
+    draw_line(2, 1, get_width() - 1, 1);
+    draw_line(2, get_height() - 1, get_width() - 1, get_height() - 1);
 
-    draw_line(5, 7, 7, 7, BLK, Magenta);
+    draw_line(5, 7, 7, 7);
 
-    draw_line(5, 5, get_width() - 5, get_height() - 5, BLK, Red);
-    draw_line(get_width() - 6, 5, 4, get_height() - 5, BLK, Cyan);
+    draw_line(5, 5, get_width() - 5, get_height() - 5);
+    draw_line(get_width() - 6, 5, 4, get_height() - 5);
 
     set_pixel(5, 5, BLK, Cyan);
     set_pixel(get_width() - 6, get_height() - 6, BLK, Cyan);
     set_pixel(5, get_height() - 6, BLK, Red);
     set_pixel(get_width() - 6, 5, BLK, Red);
 
-    draw_rect(10, get_height() / 2 - 4, 18, 9, BLK, CLR, White, Unset);
+    draw_rect(10, get_height() / 2 - 4, 18, 9);
 
-    draw_elipse(10, get_height() / 2 - 4, 18, 9, BLK, CLR, BRed, Unset);
-    draw_elipse(1, 1, get_width() - 1, get_height() - 1, BLK, CLR, BBlue, Unset);
+    draw_elipse(10, get_height() / 2 - 4, 18, 9);
+    draw_elipse(1, 1, get_width() - 1, get_height() - 1);
 
     while (1) {
         // NOTE: This is where real work would be done, prior to rendering

--- a/tests/primitives.c
+++ b/tests/primitives.c
@@ -30,30 +30,30 @@ int main(int argc, char **argv)
     // Spinner
     struct line l = {.x1 = get_width() / 2, .y1 = get_height() / 2,
                      .x2 = get_width() / 2, .y2 = 0};
-    //draw_line(l.x1, l.y1, l.x2, l.y2, DRK, Blue);
+    //line(l.x1, l.y1, l.x2, l.y2, DRK, Blue);
 
-    draw_line(0, 0, 0, get_height());
-    draw_line(1, 0, 1, get_height() - 1);
-    draw_line(get_width() - 1, 2, get_width() - 1, get_height());
+    line(0, 0, 0, get_height());
+    line(1, 0, 1, get_height() - 1);
+    line(get_width() - 1, 2, get_width() - 1, get_height());
 
-    draw_line(2, 0, get_width(), 0);
-    draw_line(2, 1, get_width() - 1, 1);
-    draw_line(2, get_height() - 1, get_width() - 1, get_height() - 1);
+    line(2, 0, get_width(), 0);
+    line(2, 1, get_width() - 1, 1);
+    line(2, get_height() - 1, get_width() - 1, get_height() - 1);
 
-    draw_line(5, 7, 7, 7);
+    line(5, 7, 7, 7);
 
-    draw_line(5, 5, get_width() - 5, get_height() - 5);
-    draw_line(get_width() - 6, 5, 4, get_height() - 5);
+    line(5, 5, get_width() - 5, get_height() - 5);
+    line(get_width() - 6, 5, 4, get_height() - 5);
 
     set_pixel(5, 5, BLK, Cyan);
     set_pixel(get_width() - 6, get_height() - 6, BLK, Cyan);
     set_pixel(5, get_height() - 6, BLK, Red);
     set_pixel(get_width() - 6, 5, BLK, Red);
 
-    draw_rect(10, get_height() / 2 - 4, 18, 9);
+    rect(10, get_height() / 2 - 4, 18, 9);
 
-    draw_elipse(10, get_height() / 2 - 4, 18, 9);
-    draw_elipse(1, 1, get_width() - 1, get_height() - 1);
+    ellipse(10, get_height() / 2 - 4, 18, 9);
+    ellipse(1, 1, get_width() - 1, get_height() - 1);
 
     while (1) {
         // NOTE: This is where real work would be done, prior to rendering

--- a/tests/rotation.c
+++ b/tests/rotation.c
@@ -1,0 +1,71 @@
+#include <stdio.h>
+
+#include "termadore.h"
+
+int main(int argc, char **argv)
+{
+    if (init_screen() != 0) {
+	fprintf(stderr, "[Error] Failed to initialise screen");
+	return 1;
+    }
+
+    int w = get_width();
+    int h = get_height();
+
+    while (1) {
+	if (detect_resize()) {
+	    kill_window();
+	    init_window();
+	}
+
+	fill(CLR, Unset);
+
+	/* Upper left lines */
+	translate(w / 4, h / 4);
+	shade(MID);
+	colour(Red);
+	line(0, 0, 10, 0);
+
+	/* Bottom right rects */
+	translate(w - w / 4,
+		  h - h / 4);
+	shade(BLK);
+	colour(Green);
+	rect(0, 0, 10, 10);
+
+	/* Upper right ellipses */
+	/* Doesn't work*/
+	translate(w - w / 4, h / 4);
+	shade(LGT);
+	colour(Cyan);
+
+	scale(2.0f);
+	ellipse(0, 0, 5, 10);
+	scale(1 / 2.0f);
+
+	/* Bottom left rects */
+	translate(w / 4, h - h / 4);
+	shade(BLK);
+	colour(Magenta);
+
+	scale(2);
+	rotate(180);
+	rect(0, 0, 10, 10);
+	rotate(180);
+	scale(0.5);
+
+	render();
+	rotate(3);
+
+	if (!kbhit())
+	    continue;
+
+	char key = fgetc(stdin);
+	if (key == 'q')
+	    break;
+    }
+
+    cleanup();
+
+    return 0;
+}

--- a/tests/rotation.c
+++ b/tests/rotation.c
@@ -39,9 +39,11 @@ int main(int argc, char **argv)
 	shade(LGT);
 	colour(Cyan);
 
+	mode(CENTRE);
 	scale(2.0f);
 	ellipse(0, 0, 5, 10);
 	scale(1 / 2.0f);
+	mode(XY);
 
 	/* Bottom left rects */
 	translate(w / 4, h - h / 4);


### PR DESCRIPTION
## Rationale
Implements origin translation, rotation, and scaling for primitive shape drawing. Proposed as a draft because there are remaining issues, see [Further Comments](#Further-Comments).

## Testing
Compile and run `./tests/rotation.c`. **Note:** line clipping is disabled in this PR.

## Further Comments
I opened a PR now so you can see the general idea behind the implementation. The following issues have to be resolved. 

- [x] Doesn't work with ellipses. Need to update `ellipse()` function.
- [x] Sometimes lines have gaps or incorrect placement of pixels. I assume it has something to do with type casting.
- [x] Update tests and demos that use primitives to use new function signatures.
- [x] Improvements to the organisation of structs and `rotated_point()` function. Perhaps, maintaining a single `State` struct for all features would be cleaner.
